### PR TITLE
[fix] 자동 배포 시 jar 파일 COPY 경로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=./build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+COPY ${JAR_FILE} ./app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
### ❗️ 이슈 번호

#13 

<br>

### 📝 구현 내용

- CD 파이프라인 중 jar 파일 COPY 명령어의 경로 수정
