### PR TITLE
feat: 댓글 삭제 기능 구현 및 테스트 추가

### DIFF
--- a/src/docs/asciidoc/comment/comment.adoc
+++ b/src/docs/asciidoc/comment/comment.adoc
@@ -2,11 +2,13 @@
 
 API : `POST /api/golrabas/{questionId}/comments`
 
-questionId = 질문 id
-
 ==== Request
+===== Path Parameter
+include::{snippets}/comment-register/path-parameters.adoc[]
+
 ===== Request Fields
 include::{snippets}/comment-register/request-fields.adoc[]
+
 ===== HTTP Request
 include::{snippets}/comment-register/http-request.adoc[]
 
@@ -17,3 +19,20 @@ include::{snippets}/comment-register/response-fields.adoc[]
 include::{snippets}/comment-register/response-body.adoc[]
 ===== HTTP Response
 include::{snippets}/comment-register/http-response.adoc[]
+
+=== 댓글 삭제
+
+API : `DELETE /api/golrabas/{questionId}/comments/{commentsId}`
+
+==== Request
+===== Path Parameter
+include::{snippets}/comment-delete/path-parameters.adoc[]
+===== Request Fields
+include::{snippets}/comment-delete/request-fields.adoc[]
+
+===== HTTP Request
+include::{snippets}/comment-delete/http-request.adoc[]
+
+==== Response
+===== HTTP Response
+include::{snippets}/comment-delete/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 = 골라바(Golraba) 애플리케이션
 이동기, <devdonggilee@gmail.com>
-v0.0.1, 23-06-27
+v0.0.1, 23-06-29
 :author: 이동기
 :email: devdonggilee@gmail.com
 :doctype: book

--- a/src/main/java/donggi/dev/kkeuroolryo/common/exception/ErrorCodeAndMessage.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/common/exception/ErrorCodeAndMessage.java
@@ -8,11 +8,14 @@ public enum ErrorCodeAndMessage {
     QUESTION_INVALID_CATEGORY("Q401", "유효하지 않은 카테고리입니다."),
     QUESTION_INVALID_CONTENT("Q402", "유효하지 않은 질문 본문입니다."),
     QUESTION_INVALID_CHOICE("Q403", "유효하지 않은 선택값입니다."),
+    QUESTION_NOT_FOUND("Q404", "존재하지 않는 질문입니다."),
 
     // comment
     COMMENT_INVALID_CONTENT("C401", "유효하지 않은 댓글 본문입니다."),
     COMMENT_INVALID_PASSWORD("C402", "유효하지 않은 댓글 비밀번호입니다."),
     COMMENT_INVALID_USERNAME("C403", "유효하지 않은 사용자 이름입니다."),
+    COMMENT_NOT_FOUND("C404", "존재하지 않은 댓글입니다."),
+    COMMENT_UNAUTHORIZED("C405", "올바르지 않은 댓글 비밀번호입니다.")
     ;
 
     private final String code;

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/application/CommentEditor.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/application/CommentEditor.java
@@ -12,4 +12,13 @@ public interface CommentEditor {
      * @return commentDto 등록된 comment 가 포함된 객체
      */
     CommentDto save(Long questionId, CommentRegisterCommand commentRegisterCommand);
+
+    /**
+     * 특정 질문의 특정 댓글을 삭제합니다.
+     *
+     * @param questionId 삭제할 댓글의 질문 id
+     * @param commentId 삭제할 댓글 id
+     * @param password 댓글 삭제 인가 확인을 위한 패스워드
+     * */
+    void delete(Long questionId, Long commentId, String password);
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/application/CommentService.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/application/CommentService.java
@@ -3,6 +3,9 @@ package donggi.dev.kkeuroolryo.core.comment.application;
 import donggi.dev.kkeuroolryo.core.comment.application.dto.CommentDto;
 import donggi.dev.kkeuroolryo.core.comment.domain.Comment;
 import donggi.dev.kkeuroolryo.core.comment.domain.CommentRepository;
+import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentNotFoundException;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionRepository;
+import donggi.dev.kkeuroolryo.core.question.domain.exception.QuestionNotFoundException;
 import donggi.dev.kkeuroolryo.web.comment.dto.CommentRegisterCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,11 +16,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentService implements CommentEditor {
 
     private final CommentRepository commentRepository;
+    private final QuestionRepository questionRepository;
 
     @Override
     @Transactional
     public CommentDto save(Long questionId, CommentRegisterCommand commentRegisterCommand) {
         Comment comment = commentRepository.save(commentRegisterCommand.convertToEntity(questionId));
         return CommentDto.ofEntity(comment);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long questionId, Long commentId, String password) {
+        questionRepository.findById(questionId)
+            .orElseThrow(QuestionNotFoundException::new);
+
+        Comment comment = commentRepository.findByQuestionIdAndId(questionId, commentId)
+            .orElseThrow(CommentNotFoundException::new);
+
+        comment.checkPassword(password);
+
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/Comment.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/Comment.java
@@ -1,5 +1,6 @@
 package donggi.dev.kkeuroolryo.core.comment.domain;
 
+import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentUnauthorizedException;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,5 +37,11 @@ public class Comment {
         this.username = new CommentUsername(username);
         this.password = new CommentPassword(password);
         this.content = new CommentContent(content);
+    }
+
+    public void checkPassword(String password) {
+        if (!this.password.getPassword().equals(password)) {
+            throw new CommentUnauthorizedException();
+        }
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentRepository.java
@@ -1,5 +1,7 @@
 package donggi.dev.kkeuroolryo.core.comment.domain;
 
+import java.util.Optional;
+
 public interface CommentRepository {
 
     /**
@@ -8,4 +10,32 @@ public interface CommentRepository {
      * @return 저장된 comment
      */
     Comment save(Comment comment);
+
+    /**
+     * 저장소에서 comment 를 검색합니다.
+     *
+     * @param commentId 검색할 id
+     * @return Optional<Comment> 객체
+     */
+    Optional<Comment> findByQuestionIdAndId(Long questionId, Long commentId);
+
+    /**
+     * 저장소에서 특정 댓글을 삭제합니다.
+     *
+     * @param comment 삭제할 글 객체
+     */
+    void delete(Comment comment);
+
+    /**
+     * 저장소에서 댓글을 모두 삭제합니다.
+     */
+    void deleteAll();
+
+    /**
+     * 저장소에서 comment 를 검색합니다.
+     *
+     * @param commentId 검색할 id
+     * @return Optional<Post> 객체
+     */
+    Optional<Comment> findById(Long commentId);
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/exception/CommentNotFoundException.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package donggi.dev.kkeuroolryo.core.comment.domain.exception;
+
+import donggi.dev.kkeuroolryo.common.exception.ErrorCodeAndMessage;
+import donggi.dev.kkeuroolryo.common.exception.GolrabaException;
+
+public class CommentNotFoundException extends GolrabaException {
+
+    public CommentNotFoundException() {
+        super(ErrorCodeAndMessage.COMMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/exception/CommentUnauthorizedException.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/exception/CommentUnauthorizedException.java
@@ -1,0 +1,11 @@
+package donggi.dev.kkeuroolryo.core.comment.domain.exception;
+
+import donggi.dev.kkeuroolryo.common.exception.ErrorCodeAndMessage;
+import donggi.dev.kkeuroolryo.common.exception.GolrabaException;
+
+public class CommentUnauthorizedException extends GolrabaException {
+
+    public CommentUnauthorizedException() {
+        super(ErrorCodeAndMessage.COMMENT_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionRepository.java
@@ -1,6 +1,7 @@
 package donggi.dev.kkeuroolryo.core.question.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository {
 
@@ -23,4 +24,17 @@ public interface QuestionRepository {
      * @return 조회한 question 리스트
      */
      List<Question> findByIdIn(List<Long> ids);
+
+    /**
+     * 저장소에서 질문을 모두 삭제합니다.
+     */
+    void deleteAll();
+
+    /**
+     * 저장소에서 question 를 검색합니다.
+     *
+     * @param questionId 검색할 id
+     * @return Optional<Question> 객체
+     */
+    Optional<Question> findById(Long questionId);
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/exception/QuestionNotFoundException.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/exception/QuestionNotFoundException.java
@@ -1,0 +1,11 @@
+package donggi.dev.kkeuroolryo.core.question.domain.exception;
+
+import donggi.dev.kkeuroolryo.common.exception.ErrorCodeAndMessage;
+import donggi.dev.kkeuroolryo.common.exception.GolrabaException;
+
+public class QuestionNotFoundException extends GolrabaException {
+
+    public QuestionNotFoundException() {
+        super(ErrorCodeAndMessage.QUESTION_INVALID_CHOICE);
+    }
+}

--- a/src/main/java/donggi/dev/kkeuroolryo/web/comment/CommentRestController.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/web/comment/CommentRestController.java
@@ -2,10 +2,12 @@ package donggi.dev.kkeuroolryo.web.comment;
 
 import donggi.dev.kkeuroolryo.core.comment.application.CommentEditor;
 import donggi.dev.kkeuroolryo.core.comment.application.dto.CommentDto;
+import donggi.dev.kkeuroolryo.web.comment.dto.CommentDeleteCommand;
 import donggi.dev.kkeuroolryo.web.comment.dto.CommentRegisterCommand;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,5 +26,12 @@ public class CommentRestController {
         @RequestBody CommentRegisterCommand commentRegisterCommand) {
         CommentDto commentDto = commentEditor.save(questionId, commentRegisterCommand);
         return ResponseEntity.created(URI.create("/api/golrabas/question")).body(commentDto);
+    }
+
+    @DeleteMapping("/{questionId}/comments/{commentId}")
+    public ResponseEntity<CommentDto> register(@PathVariable("questionId") Long questionId,
+        @PathVariable("commentId") Long commentId, @RequestBody CommentDeleteCommand commentDeleteCommand) {
+        commentEditor.delete(questionId, commentId, commentDeleteCommand.getPassword());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/web/comment/dto/CommentDeleteCommand.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/web/comment/dto/CommentDeleteCommand.java
@@ -1,0 +1,15 @@
+package donggi.dev.kkeuroolryo.web.comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentDeleteCommand {
+
+    private String password;
+
+    public CommentDeleteCommand(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -460,6 +460,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_댓글_api">2. 댓글 API</a>
 <ul class="sectlevel2">
 <li><a href="#_댓글_등록">2.1. 댓글 등록</a></li>
+<li><a href="#_댓글_삭제">2.2. 댓글 삭제</a></li>
 </ul>
 </li>
 </ul>
@@ -517,7 +518,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/question HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:64868
+Host: localhost:49680
 Content-Length: 95
 
 {
@@ -575,7 +576,7 @@ Content-Length: 95
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
-  "id" : 20,
+  "id" : 29,
   "content" : "요청한 질문 본문",
   "choiceA" : "선택 A",
   "choiceB" : "선택 B"
@@ -591,13 +592,13 @@ Content-Length: 95
 Location: /api/golrabas/question
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Tue, 27 Jun 2023 09:28:58 GMT
+Date: Thu, 29 Jun 2023 08:05:29 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 108
 
 {
-  "id" : 20,
+  "id" : 29,
   "content" : "요청한 질문 본문",
   "choiceA" : "선택 A",
   "choiceB" : "선택 B"
@@ -621,7 +622,7 @@ Content-Length: 108
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/category/self HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:64868</code></pre>
+Host: localhost:49680</code></pre>
 </div>
 </div>
 </div>
@@ -679,77 +680,77 @@ Host: localhost:64868</code></pre>
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
   "category" : "self",
   "questions" : [ {
-    "id" : 4,
+    "id" : 13,
     "content" : "질문 본문1",
     "choiceA" : "선택A 1",
     "choiceB" : "선택B 1"
   }, {
-    "id" : 5,
+    "id" : 14,
     "content" : "질문 본문2",
     "choiceA" : "선택A 2",
     "choiceB" : "선택B 2"
   }, {
-    "id" : 6,
+    "id" : 15,
     "content" : "질문 본문3",
     "choiceA" : "선택A 3",
     "choiceB" : "선택B 3"
   }, {
-    "id" : 7,
+    "id" : 16,
     "content" : "질문 본문4",
     "choiceA" : "선택A 4",
     "choiceB" : "선택B 4"
   }, {
-    "id" : 8,
+    "id" : 17,
     "content" : "질문 본문5",
     "choiceA" : "선택A 5",
     "choiceB" : "선택B 5"
   }, {
-    "id" : 9,
+    "id" : 18,
     "content" : "질문 본문6",
     "choiceA" : "선택A 6",
     "choiceB" : "선택B 6"
   }, {
-    "id" : 10,
+    "id" : 19,
     "content" : "질문 본문7",
     "choiceA" : "선택A 7",
     "choiceB" : "선택B 7"
   }, {
-    "id" : 12,
+    "id" : 20,
+    "content" : "질문 본문8",
+    "choiceA" : "선택A 8",
+    "choiceB" : "선택B 8"
+  }, {
+    "id" : 21,
     "content" : "질문 본문9",
     "choiceA" : "선택A 9",
     "choiceB" : "선택B 9"
   }, {
-    "id" : 13,
+    "id" : 22,
     "content" : "질문 본문10",
     "choiceA" : "선택A 10",
     "choiceB" : "선택B 10"
   }, {
-    "id" : 14,
+    "id" : 23,
     "content" : "질문 본문11",
     "choiceA" : "선택A 11",
     "choiceB" : "선택B 11"
   }, {
-    "id" : 15,
+    "id" : 24,
     "content" : "질문 본문12",
     "choiceA" : "선택A 12",
     "choiceB" : "선택B 12"
   }, {
-    "id" : 16,
+    "id" : 25,
     "content" : "질문 본문13",
     "choiceA" : "선택A 13",
     "choiceB" : "선택B 13"
   }, {
-    "id" : 17,
-    "content" : "질문 본문14",
-    "choiceA" : "선택A 14",
-    "choiceB" : "선택B 14"
-  }, {
-    "id" : 18,
+    "id" : 27,
     "content" : "질문 본문15",
     "choiceA" : "선택A 15",
     "choiceB" : "선택B 15"
   }, {
-    "id" : 19,
+    "id" : 28,
     "content" : "질문 본문16",
     "choiceA" : "선택A 16",
     "choiceB" : "선택B 16"
@@ -765,85 +766,85 @@ Host: localhost:64868</code></pre>
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Tue, 27 Jun 2023 09:28:58 GMT
+Date: Thu, 29 Jun 2023 08:05:29 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 1755
+Content-Length: 1758
 
 {
   "category" : "self",
   "questions" : [ {
-    "id" : 4,
+    "id" : 13,
     "content" : "질문 본문1",
     "choiceA" : "선택A 1",
     "choiceB" : "선택B 1"
   }, {
-    "id" : 5,
+    "id" : 14,
     "content" : "질문 본문2",
     "choiceA" : "선택A 2",
     "choiceB" : "선택B 2"
   }, {
-    "id" : 6,
+    "id" : 15,
     "content" : "질문 본문3",
     "choiceA" : "선택A 3",
     "choiceB" : "선택B 3"
   }, {
-    "id" : 7,
+    "id" : 16,
     "content" : "질문 본문4",
     "choiceA" : "선택A 4",
     "choiceB" : "선택B 4"
   }, {
-    "id" : 8,
+    "id" : 17,
     "content" : "질문 본문5",
     "choiceA" : "선택A 5",
     "choiceB" : "선택B 5"
   }, {
-    "id" : 9,
+    "id" : 18,
     "content" : "질문 본문6",
     "choiceA" : "선택A 6",
     "choiceB" : "선택B 6"
   }, {
-    "id" : 10,
+    "id" : 19,
     "content" : "질문 본문7",
     "choiceA" : "선택A 7",
     "choiceB" : "선택B 7"
   }, {
-    "id" : 12,
+    "id" : 20,
+    "content" : "질문 본문8",
+    "choiceA" : "선택A 8",
+    "choiceB" : "선택B 8"
+  }, {
+    "id" : 21,
     "content" : "질문 본문9",
     "choiceA" : "선택A 9",
     "choiceB" : "선택B 9"
   }, {
-    "id" : 13,
+    "id" : 22,
     "content" : "질문 본문10",
     "choiceA" : "선택A 10",
     "choiceB" : "선택B 10"
   }, {
-    "id" : 14,
+    "id" : 23,
     "content" : "질문 본문11",
     "choiceA" : "선택A 11",
     "choiceB" : "선택B 11"
   }, {
-    "id" : 15,
+    "id" : 24,
     "content" : "질문 본문12",
     "choiceA" : "선택A 12",
     "choiceB" : "선택B 12"
   }, {
-    "id" : 16,
+    "id" : 25,
     "content" : "질문 본문13",
     "choiceA" : "선택A 13",
     "choiceB" : "선택B 13"
   }, {
-    "id" : 17,
-    "content" : "질문 본문14",
-    "choiceA" : "선택A 14",
-    "choiceB" : "선택B 14"
-  }, {
-    "id" : 18,
+    "id" : 27,
     "content" : "질문 본문15",
     "choiceA" : "선택A 15",
     "choiceB" : "선택B 15"
   }, {
-    "id" : 19,
+    "id" : 28,
     "content" : "질문 본문16",
     "choiceA" : "선택A 16",
     "choiceB" : "선택B 16"
@@ -864,11 +865,30 @@ Content-Length: 1755
 <div class="paragraph">
 <p>API : <code>POST /api/golrabas/{questionId}/comments</code></p>
 </div>
-<div class="paragraph">
-<p>questionId = 질문 id</p>
-</div>
 <div class="sect3">
 <h4 id="_request_3"><a class="link" href="#_request_3">2.1.1. Request</a></h4>
+<div class="sect4">
+<h5 id="_path_parameter"><a class="link" href="#_path_parameter">Path Parameter</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /api/golrabas/{questionId}/comments</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
 <div class="sect4">
 <h5 id="_request_fields_2"><a class="link" href="#_request_fields_2">Request Fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
@@ -907,10 +927,10 @@ Content-Length: 1755
 <h5 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/1/comments HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/12/comments HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:64868
+Host: localhost:49680
 Content-Length: 98
 
 {
@@ -963,7 +983,7 @@ Content-Length: 98
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
-  "id" : 4,
+  "id" : 13,
   "username" : "유저네임",
   "content" : "댓글 본문"
 }</code></pre>
@@ -978,16 +998,105 @@ Content-Length: 98
 Location: /api/golrabas/question
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Tue, 27 Jun 2023 09:28:58 GMT
+Date: Thu, 29 Jun 2023 08:05:29 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 76
+Content-Length: 77
 
 {
-  "id" : 4,
+  "id" : 13,
   "username" : "유저네임",
   "content" : "댓글 본문"
 }</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_댓글_삭제"><a class="link" href="#_댓글_삭제">2.2. 댓글 삭제</a></h3>
+<div class="paragraph">
+<p>API : <code>DELETE /api/golrabas/{questionId}/comments/{commentsId}</code></p>
+</div>
+<div class="sect3">
+<h4 id="_request_4"><a class="link" href="#_request_4">2.2.1. Request</a></h4>
+<div class="sect4">
+<h5 id="_path_parameter_2"><a class="link" href="#_path_parameter_2">Path Parameter</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. /api/golrabas/{questionId}/comments/{commentId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_request_fields_3"><a class="link" href="#_request_fields_3">Request Fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_http_request_4"><a class="link" href="#_http_request_4">HTTP Request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/golrabas/11/comments/11 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Host: localhost:49680
+Content-Length: 36
+
+{
+  "password" : "비밀번호123"
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_4"><a class="link" href="#_response_4">2.2.2. Response</a></h4>
+<div class="sect4">
+<h5 id="_http_response_4"><a class="link" href="#_http_response_4">HTTP Response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
+Date: Thu, 29 Jun 2023 08:05:29 GMT
+Keep-Alive: timeout=60
+Connection: keep-alive</code></pre>
 </div>
 </div>
 </div>

--- a/src/test/java/donggi/dev/kkeuroolryo/RestAssuredAndRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/RestAssuredAndRestDocsTest.java
@@ -6,7 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.context.ActiveProfiles;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/donggi/dev/kkeuroolryo/core/comment/application/CommentEditorTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/core/comment/application/CommentEditorTest.java
@@ -1,17 +1,30 @@
 package donggi.dev.kkeuroolryo.core.comment.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import donggi.dev.kkeuroolryo.IntegrationTest;
 import donggi.dev.kkeuroolryo.core.comment.application.dto.CommentDto;
+import donggi.dev.kkeuroolryo.core.comment.domain.Comment;
 import donggi.dev.kkeuroolryo.core.comment.domain.CommentRepository;
+import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentNotFoundException;
+import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentUnauthorizedException;
+import donggi.dev.kkeuroolryo.core.question.domain.Question;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionRepository;
+import donggi.dev.kkeuroolryo.core.question.domain.exception.QuestionNotFoundException;
+import donggi.dev.kkeuroolryo.web.comment.dto.CommentDeleteCommand;
 import donggi.dev.kkeuroolryo.web.comment.dto.CommentRegisterCommand;
+import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("Comment 등록 IntegrationTest")
+@DisplayName("Comment 등록, 삭제 IntegrationTest")
 @IntegrationTest
 class CommentEditorTest {
 
@@ -20,6 +33,21 @@ class CommentEditorTest {
 
     @Autowired
     CommentRepository commentRepository;
+
+    @Autowired
+    QuestionRepository questionRepository;
+
+
+    Question question;
+    Comment comment;
+    @BeforeEach
+    void setUp() {
+        questionRepository.deleteAll();
+        commentRepository.deleteAll();
+
+        question = questionRepository.save(new Question("카테고리", "질문본문", "선택지A", "선택지B"));
+        comment = commentRepository.save(new Comment(question.getId(), "사용자이름", "비밀번호123", "댓글본문"));
+    }
 
     @Nested
     @DisplayName("댓글 등록 요청이")
@@ -43,6 +71,70 @@ class CommentEditorTest {
                     softly.assertThat(commentDto.getUsername()).isEqualTo(username);
                     softly.assertThat(commentDto.getContent()).isEqualTo(content);
                 });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 삭제 요청이")
+    class Describe_delete {
+
+        @Nested
+        @DisplayName("정상적이라면")
+        class Context_with_valid_delete_command {
+
+            @Test
+            @DisplayName("저장소에서 댓글을 삭제한다.")
+            void delete_comment() {
+                String password = "비밀번호123";
+                CommentDeleteCommand commentDeleteCommand = new CommentDeleteCommand(password);
+                commentEditor.delete(question.getId(), comment.getId(), commentDeleteCommand.getPassword());
+
+                Optional<Comment> deletedComment = commentRepository.findById(comment.getId());
+
+                assertThat(deletedComment).isNotPresent();
+            }
+        }
+
+        @Nested
+        @DisplayName("정상적이지 않다면 (비밀번호가 일치하지 않은 경우)")
+        class Context_with_invalid_delete_command {
+
+            @Test
+            @DisplayName("예외를 발생시킨다.")
+            void throws_exception() {
+                String unauthorizedPassword = "비밀번호486";
+
+                assertThatThrownBy(() -> commentEditor.delete(question.getId(), comment.getId(), unauthorizedPassword))
+                    .isInstanceOf(CommentUnauthorizedException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("정상적이지 않다면 (질문 id가 존재하지 않을 경우)")
+        class Context_with_invalid_question_id {
+
+            @Test
+            @DisplayName("예외를 발생시킨다.")
+            void throws_exception() {
+                Long invalidQuestionId = -1L;
+
+                assertThatThrownBy(() -> commentEditor.delete(invalidQuestionId, comment.getId(), comment.getPassword().getPassword()))
+                    .isInstanceOf(QuestionNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("정상적이지 않다면 (댓글 id가 존재하지 않을 경우)")
+        class Context_with_invalid_comment_id {
+
+            @Test
+            @DisplayName("예외를 발생시킨다.")
+            void throws_exception() {
+                Long invalidCommentId = -1L;
+
+                assertThatThrownBy(() -> commentEditor.delete(question.getId(), invalidCommentId, comment.getPassword().getPassword()))
+                    .isInstanceOf(CommentNotFoundException.class);
             }
         }
     }

--- a/src/test/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentTest.java
@@ -6,13 +6,15 @@ import donggi.dev.kkeuroolryo.UnitTest;
 import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentInvalidContentException;
 import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentInvalidPasswordException;
 import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentInvalidUsernameException;
+import donggi.dev.kkeuroolryo.core.comment.domain.exception.CommentUnauthorizedException;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.ParameterizedTest;
 
 @DisplayName("Comment 도메인 UnitTest")
 @UnitTest
@@ -106,6 +108,41 @@ class CommentTest {
             void throws_exception(String username) {
                 assertThatThrownBy(() ->  new Comment(1L, username, "정상 패스워드", "정상 댓글본문"))
                     .isInstanceOf(CommentInvalidUsernameException.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("패스워드 검증 시")
+    class Describe_Method_checkPassword {
+
+        @Nested
+        @DisplayName("작성한 패스워드가 저장된 댓글 패스워드와 일치한다면")
+        class Context_with_authorized_password {
+
+            @Test
+            @DisplayName("true 를 반환한다.")
+            void returns_true() {
+                Comment comment = new Comment(1L, "사용자이름", "패스워드123", "댓글본문");
+                String authorizedPassword = "패스워드123";
+
+                comment.checkPassword(authorizedPassword);
+            }
+        }
+
+        @Nested
+        @DisplayName("작성 패스워드가 저장된 댓글 패스워드와 일치하지 않는다면")
+        class Context_with_unauthorized_password {
+
+            @Test
+            @DisplayName("예외를 반환한다.")
+            void throws_exception() {
+                Comment comment = new Comment(1L, "사용자이름", "패스워드123", "댓글본문");
+                String unauthorizedPassword = "패스워드486";
+
+
+                assertThatThrownBy(() -> comment.checkPassword(unauthorizedPassword))
+                    .isInstanceOf(CommentUnauthorizedException.class);
             }
         }
     }

--- a/src/test/java/donggi/dev/kkeuroolryo/web/comment/CommentRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/comment/CommentRestControllerRestDocsTest.java
@@ -4,28 +4,56 @@ import static io.restassured.RestAssured.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 
 import donggi.dev.kkeuroolryo.InitRestDocsTest;
 import donggi.dev.kkeuroolryo.RestAssuredAndRestDocsTest;
+import donggi.dev.kkeuroolryo.core.comment.domain.Comment;
+import donggi.dev.kkeuroolryo.core.comment.domain.CommentRepository;
+import donggi.dev.kkeuroolryo.core.question.domain.Question;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionRepository;
+import donggi.dev.kkeuroolryo.web.comment.dto.CommentDeleteCommand;
 import donggi.dev.kkeuroolryo.web.comment.dto.CommentRegisterCommand;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
-@DisplayName("API 문서화 : 댓글 등록 요청")
+@DisplayName("API 문서화 : 댓글 등록, 삭제 요청")
 @RestAssuredAndRestDocsTest
 public class CommentRestControllerRestDocsTest extends InitRestDocsTest {
 
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    QuestionRepository questionRepository;
+
+    Question question;
+    Comment comment;
+
+    @BeforeEach
+    void setUp() {
+        questionRepository.deleteAll();
+        commentRepository.deleteAll();
+
+        question = questionRepository.save(new Question("카테고리", "질문본문", "선택지A", "선택지B"));
+        comment = commentRepository.save(new Comment(question.getId(), "사용자이름", "비밀번호123", "댓글본문"));
+    }
+
     @Test
     @DisplayName("사용자의 댓글 등록 요청이 정상적인 경우 댓글 생성 후 상태코드를 반환한다.")
-    void post_register() {
+    void comment_register() {
         CommentRegisterCommand commentRegisterCommand = new CommentRegisterCommand("유저네임", "비밀번호123", "댓글 본문");
         given(this.spec)
             .filter(
                 document("comment-register",
+                    pathParameters(parameterWithName("questionId").description("댓글 id")),
                     requestFields(
                         fieldWithPath("username").description("사용자 이름").type(JsonFieldType.STRING),
                         fieldWithPath("password").description("비밀번호").type(JsonFieldType.STRING),
@@ -41,15 +69,40 @@ public class CommentRestControllerRestDocsTest extends InitRestDocsTest {
             .log().all()
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .header("Content-type", MediaType.APPLICATION_JSON_VALUE)
-            .pathParam("questionId", "1")
             .body(commentRegisterCommand)
 
         .when()
-            .post("/api/golrabas/{questionId}/comments")
+            .post("/api/golrabas/{questionId}/comments", question.getId())
 
         .then()
             .log().all()
             .statusCode(HttpStatus.CREATED.value());
     }
 
+    @Test
+    @DisplayName("사용자의 댓글 삭제 요청이 정상적인 경우 댓글을 삭제 후 상태코드를 반환한다.")
+    void comment_delete() {
+        CommentDeleteCommand commentDeleteCommand = new CommentDeleteCommand("비밀번호123");
+        given(this.spec)
+            .filter(
+                document("comment-delete",
+                    pathParameters(
+                        parameterWithName(("questionId")).description("질문 id"),
+                        parameterWithName(("commentId")).description("댓글 id")
+                    ),
+                    requestFields(fieldWithPath("password").description("비밀번호").type(JsonFieldType.STRING))
+                )
+            )
+            .log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-type", MediaType.APPLICATION_JSON_VALUE)
+            .body(commentDeleteCommand)
+
+        .when()
+            .delete("/api/golrabas/{questionId}/comments/{commentId}", question.getId(), comment.getId())
+
+        .then()
+            .log().all()
+            .statusCode(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/src/test/java/donggi/dev/kkeuroolryo/web/comment/CommentRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/comment/CommentRestControllerRestDocsTest.java
@@ -53,7 +53,7 @@ public class CommentRestControllerRestDocsTest extends InitRestDocsTest {
         given(this.spec)
             .filter(
                 document("comment-register",
-                    pathParameters(parameterWithName("questionId").description("댓글 id")),
+                    pathParameters(parameterWithName("questionId").description("질문 id")),
                     requestFields(
                         fieldWithPath("username").description("사용자 이름").type(JsonFieldType.STRING),
                         fieldWithPath("password").description("비밀번호").type(JsonFieldType.STRING),

--- a/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
@@ -26,6 +26,8 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
 
     @BeforeEach
     void setUp() {
+        questionRepository.deleteAll();
+
         questionRepository.save(new Question("self", "질문 본문1", "선택A 1", "선택B 1"));
         questionRepository.save(new Question("self", "질문 본문2", "선택A 2", "선택B 2"));
         questionRepository.save(new Question("self", "질문 본문3", "선택A 3", "선택B 3"));
@@ -46,7 +48,7 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
 
     @Test
     @DisplayName("특정 카테고리를 선택하면 해당 카테고리 질문을 15개 반환하고 정상 상태코드를 반환한다.")
-    void post_register() {
+    void question_register() {
         given(this.spec)
             .filter(
                 document("random-questions-read",

--- a/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionRestControllerRestDocsTest.java
@@ -21,7 +21,7 @@ class QuestionRestControllerRestDocsTest extends InitRestDocsTest {
 
     @Test
     @DisplayName("사용자의 질문 등록 요청이 정상적인 경우 질문 생성 후 상태코드를 반환한다.")
-    void post_register() {
+    void question_register() {
         QuestionRegisterCommand questionRegisterCommand = new QuestionRegisterCommand("요청한 질문 본문", "선택 A", "선택 B");
         given(this.spec)
             .filter(


### PR DESCRIPTION
### ❗️ 이슈 번호

#31 

<br>

### 📝 구현 내용

실수로 main 브랜치에 작업 후 commit 하여 되돌리게 되었음

- 작업 주요 내용
  - 댓글 삭제 기능 구현
  - RestDocs 테스트 추가
  - 댓글 삭제 시 비밀번호 검증 성공 테스트 추가
  - 테스트 격리 문제 해결
  - 댓글 삭제 통합테스트 성공 케이스 추가
  - 댓글 삭제 통합테스트 실패 케이스 추가


<br>

### 💡 결과 & 참고 자료

<img width="527" alt="image" src="https://github.com/beside-kkeuroolryo/spring-server/assets/73376468/32a0a232-8189-4e87-a852-6ba7032d6e1e">

