### PR TITLE
[feat] 특정 질문 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/question/question.adoc
+++ b/src/docs/asciidoc/question/question.adoc
@@ -33,3 +33,21 @@ include::{snippets}/random-questions-read/response-fields.adoc[]
 include::{snippets}/random-questions-read/response-body.adoc[]
 ===== HTTP Response
 include::{snippets}/random-questions-read/http-response.adoc[]
+
+=== 특정 질문 조회
+
+API : `GET /api/golrabas/{questionId}`
+
+==== Request
+===== Path Parameters
+include::{snippets}/question-read/path-parameters.adoc[]
+===== HTTP Request
+include::{snippets}/question-read/http-request.adoc[]
+
+==== Response
+===== Response Fields
+include::{snippets}/question-read/response-fields.adoc[]
+===== Response Body
+include::{snippets}/question-read/response-body.adoc[]
+===== HTTP Response
+include::{snippets}/question-read/http-response.adoc[]

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionFinder.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionFinder.java
@@ -1,8 +1,23 @@
 package donggi.dev.kkeuroolryo.core.question.application;
 
+import donggi.dev.kkeuroolryo.core.question.application.dto.QuestionDto;
 import donggi.dev.kkeuroolryo.core.question.application.dto.RandomQuestionsDto;
 
 public interface QuestionFinder {
 
+    /**
+     * 특정 카테고리의 질문을 무작위로 조회합니다.
+     *
+     * @param category 카테고리 이름
+     * @return RandomQuestionsDto 무작위로 조회한 여러 Question 이 포함된 객체
+     */
     RandomQuestionsDto getRandomQuestionsByCategory(String category);
+
+    /**
+     * 특정 질문을 조회합니다.
+     *
+     * @param questionId 질문 id
+     * @return QuestionDto 조회한 Question 이 포함된 객체
+     */
+    QuestionDto getQuestion(Long questionId);
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
@@ -1,9 +1,10 @@
 package donggi.dev.kkeuroolryo.core.question.application;
 
 import donggi.dev.kkeuroolryo.core.question.application.dto.QuestionDto;
+import donggi.dev.kkeuroolryo.core.question.application.dto.RandomQuestionsDto;
 import donggi.dev.kkeuroolryo.core.question.domain.Question;
 import donggi.dev.kkeuroolryo.core.question.domain.QuestionRepository;
-import donggi.dev.kkeuroolryo.core.question.application.dto.RandomQuestionsDto;
+import donggi.dev.kkeuroolryo.core.question.domain.exception.QuestionNotFoundException;
 import donggi.dev.kkeuroolryo.web.question.dto.QuestionRegisterCommand;
 import java.util.Collections;
 import java.util.List;
@@ -41,5 +42,13 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
     private List<Long> getRandomQuestionIds(List<Long> questionIds) {
         Collections.shuffle(questionIds);
         return questionIds.subList(0, Math.min(questionIds.size(), RANDOM_QUESTION_COUNT));
+    }
+
+    @Override
+    public QuestionDto getQuestion(Long questionId) {
+        Question question = questionRepository.findById(questionId)
+            .orElseThrow(QuestionNotFoundException::new);
+
+        return QuestionDto.ofEntity(question);
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
@@ -4,6 +4,8 @@ import donggi.dev.kkeuroolryo.core.question.application.dto.QuestionDto;
 import donggi.dev.kkeuroolryo.core.question.application.dto.RandomQuestionsDto;
 import donggi.dev.kkeuroolryo.core.question.domain.Question;
 import donggi.dev.kkeuroolryo.core.question.domain.QuestionRepository;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionResult;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionResultRepository;
 import donggi.dev.kkeuroolryo.core.question.domain.exception.QuestionNotFoundException;
 import donggi.dev.kkeuroolryo.web.question.dto.QuestionRegisterCommand;
 import java.util.Collections;
@@ -19,11 +21,15 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
     public static final int RANDOM_QUESTION_COUNT = 15;
 
     private final QuestionRepository questionRepository;
+    private final QuestionResultRepository questionResultRepository;
 
     @Override
     @Transactional
     public QuestionDto save(QuestionRegisterCommand questionRegisterCommand) {
         Question question = questionRepository.save(questionRegisterCommand.convertToEntity());
+
+        questionResultRepository.save(new QuestionResult(question));
+
         return QuestionDto.ofEntity(question);
     }
 
@@ -48,6 +54,6 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
         Question question = questionRepository.findById(questionId)
             .orElseThrow(QuestionNotFoundException::new);
 
-        return QuestionDto.ofEntity(question);
+        return QuestionDto.ofEntity(question, question.getQuestionResult());
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
@@ -34,9 +34,7 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
 
         List<Long> randomQuestionIds = getRandomQuestionIds(questionIds);
 
-        List<Question> randomQuestions = questionRepository.findByIdIn(randomQuestionIds);
-
-        return RandomQuestionsDto.ofEntity(category, randomQuestions);
+        return RandomQuestionsDto.ofEntity(category, randomQuestionIds);
     }
 
     private List<Long> getRandomQuestionIds(List<Long> questionIds) {
@@ -45,6 +43,7 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public QuestionDto getQuestion(Long questionId) {
         Question question = questionRepository.findById(questionId)
             .orElseThrow(QuestionNotFoundException::new);

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/dto/QuestionDto.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/dto/QuestionDto.java
@@ -1,6 +1,7 @@
 package donggi.dev.kkeuroolryo.core.question.application.dto;
 
 import donggi.dev.kkeuroolryo.core.question.domain.Question;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionResult;
 import lombok.Getter;
 
 @Getter
@@ -13,19 +14,28 @@ public class QuestionDto {
     private int choiceAResult;
     private int choiceBResult;
 
+    public static QuestionDto ofEntity(Question question, QuestionResult questionResult) {
+        QuestionDto questionDto = new QuestionDto();
+        questionDto.id = question.getId();
+        questionDto.content = question.getContent().getContent();
+        questionDto.choiceA = question.getChoiceA().getChoice();
+        questionDto.choiceB = question.getChoiceB().getChoice();
+        int totalChoices = questionResult.getChoiceAResult() + questionResult.getChoiceBResult();
+        questionDto.choiceAResult = calculateChoiceCount(totalChoices, questionResult.getChoiceAResult());
+        questionDto.choiceBResult = calculateChoiceCount(totalChoices, questionResult.getChoiceBResult());
+        return questionDto;
+    }
+
     public static QuestionDto ofEntity(Question question) {
         QuestionDto questionDto = new QuestionDto();
         questionDto.id = question.getId();
         questionDto.content = question.getContent().getContent();
         questionDto.choiceA = question.getChoiceA().getChoice();
         questionDto.choiceB = question.getChoiceB().getChoice();
-        int totalChoices = question.getQuestionResult().getChoiceAResult() + question.getQuestionResult().getChoiceBResult();
-        questionDto.choiceAResult = foo(totalChoices, question.getQuestionResult().getChoiceAResult());
-        questionDto.choiceBResult = foo(totalChoices, question.getQuestionResult().getChoiceBResult());
         return questionDto;
     }
 
-    private static int foo(int totalChoices, int targetResult) {
+    private static int calculateChoiceCount(int totalChoices, int targetResult) {
         return (int) Math.round((double) targetResult / totalChoices * 100);
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/dto/QuestionDto.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/dto/QuestionDto.java
@@ -10,6 +10,8 @@ public class QuestionDto {
     private String content;
     private String choiceA;
     private String choiceB;
+    private int choiceAResult;
+    private int choiceBResult;
 
     public static QuestionDto ofEntity(Question question) {
         QuestionDto questionDto = new QuestionDto();
@@ -17,6 +19,13 @@ public class QuestionDto {
         questionDto.content = question.getContent().getContent();
         questionDto.choiceA = question.getChoiceA().getChoice();
         questionDto.choiceB = question.getChoiceB().getChoice();
+        int totalChoices = question.getQuestionResult().getChoiceAResult() + question.getQuestionResult().getChoiceBResult();
+        questionDto.choiceAResult = foo(totalChoices, question.getQuestionResult().getChoiceAResult());
+        questionDto.choiceBResult = foo(totalChoices, question.getQuestionResult().getChoiceBResult());
         return questionDto;
+    }
+
+    private static int foo(int totalChoices, int targetResult) {
+        return (int) Math.round((double) targetResult / totalChoices * 100);
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/dto/RandomQuestionsDto.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/dto/RandomQuestionsDto.java
@@ -1,25 +1,19 @@
 package donggi.dev.kkeuroolryo.core.question.application.dto;
 
-import donggi.dev.kkeuroolryo.core.question.domain.Question;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
 public class RandomQuestionsDto {
 
     private String category;
-    private List<QuestionDto> questions = new ArrayList<>();
+    private List<Long> questionIds = new ArrayList<>();
 
-    public static RandomQuestionsDto ofEntity(String category, List<Question> questions) {
+    public static RandomQuestionsDto ofEntity(String category, List<Long> questionIds) {
         RandomQuestionsDto randomQuestionsDto = new RandomQuestionsDto();
-
-        randomQuestionsDto.category = (category);
-        randomQuestionsDto.questions = questions.stream()
-            .map(question -> QuestionDto.ofEntity(question))
-            .collect(Collectors.toList());
-
+        randomQuestionsDto.category = category;
+        randomQuestionsDto.questionIds = questionIds;
         return randomQuestionsDto;
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/Question.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/Question.java
@@ -2,6 +2,7 @@ package donggi.dev.kkeuroolryo.core.question.domain;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -9,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,6 +43,9 @@ public class Question {
         @AttributeOverride(name = "choice", column = @Column(name = "choice_b"))
     })
     private QuestionChoice choiceB;
+
+    @OneToOne(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    private QuestionResult questionResult;
 
     public Question(String category, String content, String choiceA, String choiceB) {
         this.category = category;

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionRepository.java
@@ -19,13 +19,6 @@ public interface QuestionRepository {
      Question save(Question question);
 
     /**
-     * 저장소에서 id 리스트의 question을 조회합니다.
-     * @param ids 조회할 아이디 리스트
-     * @return 조회한 question 리스트
-     */
-     List<Question> findByIdIn(List<Long> ids);
-
-    /**
      * 저장소에서 질문을 모두 삭제합니다.
      */
     void deleteAll();

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionResult.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionResult.java
@@ -1,0 +1,40 @@
+package donggi.dev.kkeuroolryo.core.question.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "question_result")
+public class QuestionResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @Column(name = "choice_a_result", columnDefinition = "integer default 0", nullable = false)
+    private int choiceAResult;
+
+    @Column(name = "choice_b_result", columnDefinition = "integer default 0", nullable = false)
+    private int choiceBResult;
+
+    public QuestionResult(Question question, int choiceAResult, int choiceBResult) {
+        this.question = question;
+        this.choiceAResult = choiceAResult;
+        this.choiceBResult = choiceBResult;
+    }
+}

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionResult.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionResult.java
@@ -32,9 +32,7 @@ public class QuestionResult {
     @Column(name = "choice_b_result", columnDefinition = "integer default 0", nullable = false)
     private int choiceBResult;
 
-    public QuestionResult(Question question, int choiceAResult, int choiceBResult) {
+    public QuestionResult(Question question) {
         this.question = question;
-        this.choiceAResult = choiceAResult;
-        this.choiceBResult = choiceBResult;
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionResultRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionResultRepository.java
@@ -1,0 +1,11 @@
+package donggi.dev.kkeuroolryo.core.question.domain;
+
+public interface QuestionResultRepository {
+
+    /**
+     * questionResult 를 저장소에 저장합니다.
+     * @param questionResult 저장할 questionResult
+     * @return 저장된 QuestionResult
+     */
+    QuestionResult save(QuestionResult questionResult);
+}

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/infrastructure/QuestionJpaRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/infrastructure/QuestionJpaRepository.java
@@ -11,6 +11,4 @@ public interface QuestionJpaRepository extends QuestionRepository, JpaRepository
 
     @Query(value = "select q.id from Question q where q.category= :category")
     List<Long> findAllIdsByCategory(@Param("category") String category);
-
-    List<Question> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/infrastructure/QuestionResultJpaRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/infrastructure/QuestionResultJpaRepository.java
@@ -1,0 +1,9 @@
+package donggi.dev.kkeuroolryo.core.question.infrastructure;
+
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionResult;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionResultRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionResultJpaRepository extends QuestionResultRepository, JpaRepository<QuestionResult, Long> {
+
+}

--- a/src/main/java/donggi/dev/kkeuroolryo/web/question/QuestionRestController.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/web/question/QuestionRestController.java
@@ -34,4 +34,10 @@ public class QuestionRestController {
         RandomQuestionsDto randomQuestionsDto = questionFinder.getRandomQuestionsByCategory(category);
         return ResponseEntity.ok().body(randomQuestionsDto);
     }
+
+    @GetMapping("/{questionId}")
+    public ResponseEntity<QuestionDto> getQuestion(@PathVariable("questionId") Long questionId) {
+        QuestionDto questionDto = questionFinder.getQuestion(questionId);
+        return ResponseEntity.ok().body(questionDto);
+    }
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -455,6 +455,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_질문_등록">1.1. 질문 등록</a></li>
 <li><a href="#_카테고리_질문_조회">1.2. 카테고리 질문 조회</a></li>
+<li><a href="#_특정_질문_조회">1.3. 특정 질문 조회</a></li>
 </ul>
 </li>
 <li><a href="#_댓글_api">2. 댓글 API</a>
@@ -519,7 +520,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/question HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:54807
+Host: localhost:56766
 Content-Length: 95
 
 {
@@ -577,7 +578,7 @@ Content-Length: 95
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
-  "id" : 30,
+  "id" : 46,
   "content" : "요청한 질문 본문",
   "choiceA" : "선택 A",
   "choiceB" : "선택 B"
@@ -593,13 +594,13 @@ Content-Length: 95
 Location: /api/golrabas/question
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Thu, 29 Jun 2023 14:27:43 GMT
+Date: Fri, 30 Jun 2023 01:24:46 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 108
 
 {
-  "id" : 30,
+  "id" : 46,
   "content" : "요청한 질문 본문",
   "choiceA" : "선택 A",
   "choiceB" : "선택 B"
@@ -645,7 +646,7 @@ Content-Length: 108
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/category/self HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:54807</code></pre>
+Host: localhost:56766</code></pre>
 </div>
 </div>
 </div>
@@ -708,6 +709,11 @@ Host: localhost:54807</code></pre>
     "choiceA" : "선택A 1",
     "choiceB" : "선택B 1"
   }, {
+    "id" : 15,
+    "content" : "질문 본문2",
+    "choiceA" : "선택A 2",
+    "choiceB" : "선택B 2"
+  }, {
     "id" : 16,
     "content" : "질문 본문3",
     "choiceA" : "선택A 3",
@@ -767,11 +773,6 @@ Host: localhost:54807</code></pre>
     "content" : "질문 본문14",
     "choiceA" : "선택A 14",
     "choiceB" : "선택B 14"
-  }, {
-    "id" : 28,
-    "content" : "질문 본문15",
-    "choiceA" : "선택A 15",
-    "choiceB" : "선택B 15"
   }, {
     "id" : 29,
     "content" : "질문 본문16",
@@ -789,10 +790,10 @@ Host: localhost:54807</code></pre>
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Thu, 29 Jun 2023 14:27:43 GMT
+Date: Fri, 30 Jun 2023 01:24:46 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 1761
+Content-Length: 1758
 
 {
   "category" : "self",
@@ -801,6 +802,11 @@ Content-Length: 1761
     "content" : "질문 본문1",
     "choiceA" : "선택A 1",
     "choiceB" : "선택B 1"
+  }, {
+    "id" : 15,
+    "content" : "질문 본문2",
+    "choiceA" : "선택A 2",
+    "choiceB" : "선택B 2"
   }, {
     "id" : 16,
     "content" : "질문 본문3",
@@ -862,17 +868,36 @@ Content-Length: 1761
     "choiceA" : "선택A 14",
     "choiceB" : "선택B 14"
   }, {
-    "id" : 28,
-    "content" : "질문 본문15",
-    "choiceA" : "선택A 15",
-    "choiceB" : "선택B 15"
-  }, {
     "id" : 29,
     "content" : "질문 본문16",
     "choiceA" : "선택A 16",
     "choiceB" : "선택B 16"
   } ]
 }</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_특정_질문_조회"><a class="link" href="#_특정_질문_조회">1.3. 특정 질문 조회</a></h3>
+<div class="paragraph">
+<p>API : <code>GET /api/golrabas/{questionId}</code></p>
+</div>
+<div class="sect3">
+<h4 id="_request_3"><a class="link" href="#_request_3">1.3.1. Request</a></h4>
+<div class="sect4">
+<h5 id="_path_parameters_2"><a class="link" href="#_path_parameters_2">Path Parameters</a></h5>
+
+</div>
+<div class="sect4">
+<h5 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP Request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/category/self HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Host: localhost:56766</code></pre>
 </div>
 </div>
 </div>
@@ -889,7 +914,7 @@ Content-Length: 1761
 <p>API : <code>POST /api/golrabas/{questionId}/comments</code></p>
 </div>
 <div class="sect3">
-<h4 id="_request_3"><a class="link" href="#_request_3">2.1.1. Request</a></h4>
+<h4 id="_request_4"><a class="link" href="#_request_4">2.1.1. Request</a></h4>
 <div class="sect4">
 <h5 id="_path_parameter"><a class="link" href="#_path_parameter">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
@@ -947,13 +972,13 @@ Content-Length: 1761
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP Request</a></h5>
+<h5 id="_http_request_4"><a class="link" href="#_http_request_4">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/13/comments HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:54807
+Host: localhost:56766
 Content-Length: 98
 
 {
@@ -1021,7 +1046,7 @@ Content-Length: 98
 Location: /api/golrabas/question
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Thu, 29 Jun 2023 14:27:43 GMT
+Date: Fri, 30 Jun 2023 01:24:46 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 77
@@ -1042,7 +1067,7 @@ Content-Length: 77
 <p>API : <code>DELETE /api/golrabas/{questionId}/comments/{commentsId}</code></p>
 </div>
 <div class="sect3">
-<h4 id="_request_4"><a class="link" href="#_request_4">2.2.1. Request</a></h4>
+<h4 id="_request_5"><a class="link" href="#_request_5">2.2.1. Request</a></h4>
 <div class="sect4">
 <h5 id="_path_parameter_2"><a class="link" href="#_path_parameter_2">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
@@ -1094,13 +1119,13 @@ Content-Length: 77
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_4"><a class="link" href="#_http_request_4">HTTP Request</a></h5>
+<h5 id="_http_request_5"><a class="link" href="#_http_request_5">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/golrabas/12/comments/16 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:54807
+Host: localhost:56766
 Content-Length: 36
 
 {
@@ -1117,7 +1142,7 @@ Content-Length: 36
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
-Date: Thu, 29 Jun 2023 14:27:43 GMT
+Date: Fri, 30 Jun 2023 01:24:46 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive</code></pre>
 </div>
@@ -1131,7 +1156,7 @@ Connection: keep-alive</code></pre>
 <p>API : <code>GET /api/golrabas/{questionId}/comments/</code></p>
 </div>
 <div class="sect3">
-<h4 id="_request_5"><a class="link" href="#_request_5">2.3.1. Request</a></h4>
+<h4 id="_request_6"><a class="link" href="#_request_6">2.3.1. Request</a></h4>
 <div class="sect4">
 <h5 id="_path_parameter_3"><a class="link" href="#_path_parameter_3">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
@@ -1155,13 +1180,13 @@ Connection: keep-alive</code></pre>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_5"><a class="link" href="#_http_request_5">HTTP Request</a></h5>
+<h5 id="_http_request_6"><a class="link" href="#_http_request_6">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/11/comments?searchAfterId=15&amp;size=5 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:54807</code></pre>
+Host: localhost:56766</code></pre>
 </div>
 </div>
 </div>
@@ -1175,7 +1200,7 @@ Host: localhost:54807</code></pre>
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Thu, 29 Jun 2023 14:27:43 GMT
+Date: Fri, 30 Jun 2023 01:24:46 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 568

--- a/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
@@ -53,7 +53,7 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
         questionRepository.save(new Question("self", "질문 본문14", "선택A 14", "선택B 14"));
         questionRepository.save(new Question("self", "질문 본문15", "선택A 15", "선택B 15"));
         question = questionRepository.save(new Question("self", "질문 본문16", "선택A 16", "선택B 16"));
-        questionResultRepository.save(new QuestionResult(question, 10, 15));
+        questionResultRepository.save(new QuestionResult(question));
     }
 
     @Test

--- a/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
@@ -57,7 +57,7 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
     }
 
     @Test
-    @DisplayName("특정 카테고리를 선택하면 해당 카테고리 질문을 15개 반환하고 정상 상태코드를 반환한다.")
+    @DisplayName("특정 카테고리를 선택하면 해당 카테고리 질문 id List 를 반환하고 정상 상태코드를 반환한다.")
     void questions_read() {
         given(this.spec)
             .filter(
@@ -65,17 +65,14 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
                     pathParameters(parameterWithName("category").description("질문 카테고리")),
                     responseFields(
                         fieldWithPath("category").description("질문 카테고리").type(JsonFieldType.STRING),
-                        fieldWithPath("questions[].id").description("질문 아이디").type(JsonFieldType.NUMBER),
-                        fieldWithPath("questions[].content").description("질문 본문").type(JsonFieldType.STRING),
-                        fieldWithPath("questions[].choiceA").description("선택지 A").type(JsonFieldType.STRING),
-                        fieldWithPath("questions[].choiceB").description("선택지 B").type(JsonFieldType.STRING)
+                        fieldWithPath("questionIds").description("질문 id 리스트").type(JsonFieldType.ARRAY)
                     )
                 )
             )
             .log().all()
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .header("Content-type", MediaType.APPLICATION_JSON_VALUE)
-            .pathParam("category", "self")
+            .pathParam("category", question.getCategory())
 
         .when()
             .get("/api/golrabas/category/{category}")

--- a/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
@@ -11,6 +11,8 @@ import donggi.dev.kkeuroolryo.InitRestDocsTest;
 import donggi.dev.kkeuroolryo.RestAssuredAndRestDocsTest;
 import donggi.dev.kkeuroolryo.core.question.domain.Question;
 import donggi.dev.kkeuroolryo.core.question.domain.QuestionRepository;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionResult;
+import donggi.dev.kkeuroolryo.core.question.domain.QuestionResultRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,11 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
 
     @Autowired
     QuestionRepository questionRepository;
+
+    @Autowired
+    QuestionResultRepository questionResultRepository;
+
+    Question question;
 
     @BeforeEach
     void setUp() {
@@ -45,7 +52,8 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
         questionRepository.save(new Question("self", "질문 본문13", "선택A 13", "선택B 13"));
         questionRepository.save(new Question("self", "질문 본문14", "선택A 14", "선택B 14"));
         questionRepository.save(new Question("self", "질문 본문15", "선택A 15", "선택B 15"));
-        questionRepository.save(new Question("self", "질문 본문16", "선택A 16", "선택B 16"));
+        question = questionRepository.save(new Question("self", "질문 본문16", "선택A 16", "선택B 16"));
+        questionResultRepository.save(new QuestionResult(question, 10, 15));
     }
 
     @Test
@@ -71,6 +79,36 @@ public class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
 
         .when()
             .get("/api/golrabas/category/{category}")
+
+        .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("특정 질문 조회 요청이 주어지면 해당 질문을 반환하고 정상 상태코드를 반환한다.")
+    void question_read() {
+        given(this.spec)
+            .filter(
+                document("question-read",
+                    pathParameters(parameterWithName("questionId").description("질문 id")),
+                    responseFields(
+                        fieldWithPath("id").description("질문 id").type(JsonFieldType.NUMBER),
+                        fieldWithPath("content").description("질문 본문").type(JsonFieldType.STRING),
+                        fieldWithPath("choiceA").description("선택지 A").type(JsonFieldType.STRING),
+                        fieldWithPath("choiceB").description("선택지 B").type(JsonFieldType.STRING),
+                        fieldWithPath("choiceAResult").description("선택지 A의 득표율").type(JsonFieldType.NUMBER),
+                        fieldWithPath("choiceBResult").description("선택지 B의 득표율").type(JsonFieldType.NUMBER)
+                    )
+                )
+            )
+            .log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-type", MediaType.APPLICATION_JSON_VALUE)
+            .pathParam("questionId", question.getId())
+
+        .when()
+            .get("/api/golrabas/{questionId}", question.getId())
 
         .then()
             .log().all()

--- a/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionRestControllerRestDocsTest.java
@@ -32,10 +32,12 @@ class QuestionRestControllerRestDocsTest extends InitRestDocsTest {
                         fieldWithPath("choiceB").description("선택지 B").type(JsonFieldType.STRING)
                     ),
                     responseFields(
-                        fieldWithPath("id").description("골라바 질문 아이디").type(JsonFieldType.NUMBER),
+                        fieldWithPath("id").description("질문 id").type(JsonFieldType.NUMBER),
                         fieldWithPath("content").description("요청한 질문 본문").type(JsonFieldType.STRING),
                         fieldWithPath("choiceA").description("선택지 A").type(JsonFieldType.STRING),
-                        fieldWithPath("choiceB").description("선택지 B").type(JsonFieldType.STRING)
+                        fieldWithPath("choiceB").description("선택지 B").type(JsonFieldType.STRING),
+                        fieldWithPath("choiceAResult").description("선택지 A 선택된 횟수").type(JsonFieldType.NUMBER),
+                        fieldWithPath("choiceBResult").description("선택지 B 선택된 횟수").type(JsonFieldType.NUMBER)
                     )
                 )
             )


### PR DESCRIPTION
### ❗️ 이슈 번호

#37 
#38 

<br>

### 📝 구현 내용

- 특정 카테고리 질문 조회 시 질문 id 리스트로 반환하도록 변경
- 특정 질문 조회 기능 구현
- 특정 질문 조회 기능 RestDocs 테스트 추가
- 특정 질문 조회 API 문서 추가

<br>

### 💡 결과 & 참고 자료

<img width="703" alt="image" src="https://github.com/beside-kkeuroolryo/spring-server/assets/73376468/a59faa5c-24f7-45b1-86e4-6f848a0f9928">