### PR TITLE
[refactor] 댓글 비밀번호 예외 응답 메세지 수정 및 질문, 댓글 생성 시 글자수 제한 변경

### DIFF
--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentContent.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentContent.java
@@ -13,7 +13,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CommentContent {
 
-    public static final int LIMIT_LENGTH = 200;
+    public static final int LIMIT_LENGTH = 100;
+
     @Column(nullable = false)
     private String content;
 

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentPassword.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentPassword.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CommentPassword {
 
-    private static final int MINIMUM_LENGTH = 6;
+    private static final int MINIMUM_LENGTH = 4;
 
     @Column(nullable = false)
     private String password;

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentPassword.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentPassword.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class CommentPassword {
 
     private static final int MINIMUM_LENGTH = 4;
+    private static final int LIMIT_LENGTH = 15;
 
     @Column(nullable = false)
     private String password;
@@ -22,7 +23,8 @@ public class CommentPassword {
         if (Objects.isNull(password)
             || password.isEmpty()
             || password.chars().allMatch(Character::isWhitespace)
-            || password.length() < MINIMUM_LENGTH) {
+            || password.length() < MINIMUM_LENGTH
+            || password.length() > LIMIT_LENGTH) {
             throw new CommentInvalidPasswordException();
         }
 

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentUsername.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentUsername.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CommentUsername {
 
-    private static final int LIMIT_LENGTH = 20;
+    private static final int LIMIT_LENGTH = 15;
 
     @Column(nullable = false)
     private String username;

--- a/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/exception/CommentInvalidPasswordException.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/comment/domain/exception/CommentInvalidPasswordException.java
@@ -6,6 +6,6 @@ import donggi.dev.kkeuroolryo.common.exception.GolrabaException;
 public class CommentInvalidPasswordException extends GolrabaException {
 
     public CommentInvalidPasswordException() {
-        super(ErrorCodeAndMessage.QUESTION_INVALID_CHOICE);
+        super(ErrorCodeAndMessage.COMMENT_INVALID_PASSWORD);
     }
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionContent.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionContent.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class QuestionContent {
 
-    private static final int LIMIT_LENGTH = 400;
+    private static final int LIMIT_LENGTH = 100;
 
     @Column(length = LIMIT_LENGTH, nullable = false)
     private String content;

--- a/src/test/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/core/comment/domain/CommentTest.java
@@ -76,7 +76,7 @@ class CommentTest {
         class Context_with_minimum_password {
 
             @ParameterizedTest
-            @ValueSource(strings = {"15323", "1234", "123", "dd", "d"})
+            @ValueSource(strings = {"123", "dd", "d"})
             @DisplayName("예외를 발생시킨다.")
             void throws_exception(String password) {
                 assertThatThrownBy(() -> new Comment(1L, "정상 사용자이름", password, "정상 댓글본문"))


### PR DESCRIPTION
### ❗️ 이슈 번호

#58 

<br>

### 📝 구현 내용

- 댓글 비밀번호 예외 응답 메세지 수정 및 질문
- 댓글 생성 시 글자수 제한 변경
  - 사용자이름 15자까지 제한
  - 비밀번호 15자까지 제한
  - 댓글 생성 시 본문 100자까지 제한
  - 질문 생성 시 본문 100자까지 제한
